### PR TITLE
[Feat] 목표 비율 설정 후 캘린더 및 관심 분야 선택 플로우 연결 

### DIFF
--- a/Planvas/Planvas/Features/Calendar/Navigation/CalendarFlowView.swift
+++ b/Planvas/Planvas/Features/Calendar/Navigation/CalendarFlowView.swift
@@ -8,7 +8,9 @@
 import SwiftUI
 
 struct CalendarFlowView: View {
-    @State private var router = NavigationRouter<CalendarRoute>()
+//    @State private var router = NavigationRouter<CalendarRoute>()
+    @Environment(NavigationRouter<OnboardingRoute>.self) private var onboardingRouter
+
     @State private var viewModel = CalendarViewModel()
     @State private var syncViewModel = CalendarSyncViewModel()
     @State private var isCalendarOnly = false
@@ -23,10 +25,13 @@ struct CalendarFlowView: View {
                                 await viewModel.refreshAfterGoogleConnect()
                             })
                         }
+                    },
+                    onFinish: {
+                        // 온보딩 다음 단계로 이동
+                        onboardingRouter.push(.interest)
                     }
                 )
             } else {
-                NavigationStack(path: $router.path) {
                     CalendarSyncView(
                         viewModel: syncViewModel,
                         onDirectInput: { isCalendarOnly = true },
@@ -35,10 +40,8 @@ struct CalendarFlowView: View {
                             isCalendarOnly = true
                         }
                     )
-                }
             }
         }
-        .environment(router)
         .environment(viewModel)
     }
 }

--- a/Planvas/Planvas/Features/Calendar/View/CalendarView.swift
+++ b/Planvas/Planvas/Features/Calendar/View/CalendarView.swift
@@ -14,6 +14,8 @@ struct CalendarView: View {
     @Environment(CalendarViewModel.self) private var viewModel
     /// 미연동 시 "일정 가져오기" 알림에서 "Google 캘린더 연동" 탭 시 바로 연동 API 호출 + 일정 새로고침 (Sync 뷰 없음)
     var onConnectGoogleCalendar: (() -> Void)?
+    var onFinish: (() -> Void)?
+    
     @State private var showScheduleSelection = false
     @State private var showImportAlert = false
     @State private var showAddEvent = false
@@ -473,13 +475,14 @@ struct CalendarView: View {
             }
             
             PrimaryButton(title: "완료") {
-                // 완료 액션
+                // 완료 액션 - 완료 누르면 온보딩의 관심 분야 선택 뷰로 넘어가도록
+                onFinish?()
             }
         }
     }
 }
 
 #Preview {
-    CalendarView()
+    CalendarView(onFinish: {})
         .environment(CalendarViewModel())
 }

--- a/Planvas/Planvas/Features/Onboarding/Navigation/OnboardingFlowView.swift
+++ b/Planvas/Planvas/Features/Onboarding/Navigation/OnboardingFlowView.swift
@@ -37,6 +37,10 @@ struct OnboardingFlowView: View {
                         case .recommendation:
                             RecommendedRatioSelectionView()
                         
+                        // 캘린더
+                        case .calendar:
+                            CalendarFlowView()
+                            
                         // 관심 분야 선택
                         case .interest:
                             InterestActivitySelectionView(

--- a/Planvas/Planvas/Features/Onboarding/Navigation/OnboardingRoute.swift
+++ b/Planvas/Planvas/Features/Onboarding/Navigation/OnboardingRoute.swift
@@ -13,6 +13,7 @@ enum OnboardingRoute {
     case info   // 목표 이름, 기간 설정
     case ratio  // 목표 비율 설정
     case recommendation    // 유형별 비율 추천 선택
+    case calendar   // 캘린더
     case interest   // 관심 분야 선택
     case mainPage    // 메인 페이지
 }

--- a/Planvas/Planvas/Features/Onboarding/View/GoalRatioSetupView.swift
+++ b/Planvas/Planvas/Features/Onboarding/View/GoalRatioSetupView.swift
@@ -58,6 +58,7 @@ struct GoalRatioSetupView: View {
                     // 다음 버튼
                     PrimaryButton(title: "다음") {
                         print("성장: \(vm.growthPercent)% / 휴식: \(vm.restPercent)%")
+                        
                         // 목표 이름, 기간, 비율 저장 API 연동
                         onboardingVM.createGoal(
                             title: vm.goalName,
@@ -75,6 +76,15 @@ struct GoalRatioSetupView: View {
             .ignoresSafeArea(edges: .bottom)
         }
         .ignoresSafeArea(edges: .top)
+        // TODO: 일단 기존 목표가 있어도 캘린더로 가도록
+        .onChange(of: onboardingVM.createdGoalId) { _, newValue in
+            guard newValue != nil else { return }
+            router.push(.calendar)
+        }
+        .onChange(of: onboardingVM.currentGoalId) { _, newValue in
+            guard newValue != nil else { return }
+            router.push(.calendar)
+        }
     }
     
     // MARK: - 맨 위 멘트 그룹
@@ -114,7 +124,7 @@ struct GoalRatioSetupView: View {
             Button(action: {
                 print("유형별 추천 비율 선택 버튼 클릭")
                 
-                // TODO: 유형별 추천 비율 선택 화면 연결
+                // 유형별 추천 비율 선택 화면 연결
                 router.push(.recommendation)
             }) {
                 Text("유형별 추천 비율 선택하기")

--- a/Planvas/Planvas/Features/Onboarding/ViewModels/OnboardingViewModel.swift
+++ b/Planvas/Planvas/Features/Onboarding/ViewModels/OnboardingViewModel.swift
@@ -13,23 +13,25 @@ import Moya
 @MainActor
 final class OnboardingViewModel {
     private let provider: MoyaProvider<OnboardingAPI>
-    
+
     init(provider: MoyaProvider<OnboardingAPI>) {
         self.provider = provider
     }
 
+    // MARK: - State
+    var currentGoalId: Int? = nil
     var createdGoalId: Int? = nil
     var isLoading: Bool = false
     var errorMessage: String? = nil
-    
-    // 유형별 비율 추천 목록 상태 추가
+
+    // 유형별 비율 추천 목록
     var ratioPresets: [RatioPreset] = []
-    
+
     // 사용자가 선택한 프리셋 기억
     var selectedPresetId: Int? = nil
     var selectedPresetStep: Int? = nil
-    
-    // MARK: - 목표 기간/이름 생성
+
+    // MARK: - 목표 기간/이름 생성 (POST)
     func createGoal(
         title: String,
         startDate: String,
@@ -37,10 +39,23 @@ final class OnboardingViewModel {
         targetGrowthRatio: Int,
         targetRestRatio: Int
     ) {
+        // 입력값 최소 검증
+        guard !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            errorMessage = "목표 이름이 비어있어요."
+            return
+        }
+        guard !startDate.isEmpty, !endDate.isEmpty else {
+            errorMessage = "목표 기간이 비어있어요."
+            return
+        }
+
         isLoading = true
+        errorMessage = nil
+        createdGoalId = nil
+        currentGoalId = nil
 
         let request = CreateGoalRequestDTO(
-            presetId: selectedPresetId, // 자동으로 nil / 선택한 프리셋 id (선택한 프리셋에서 커스텀하면 nil이 됨)
+            presetId: selectedPresetId,
             title: title,
             startDate: startDate,
             endDate: endDate,
@@ -51,33 +66,105 @@ final class OnboardingViewModel {
         provider.request(.postGoalBase(CreateGoalRequestDTO: request)) { [weak self] result in
             guard let self else { return }
 
-            self.isLoading = false
-
             switch result {
             case .success(let response):
                 do {
                     let decoded = try JSONDecoder().decode(CreateGoalResponse.self, from: response.data)
 
-                    if let success = decoded.success {
-                        DispatchQueue.main.async {
+                    DispatchQueue.main.async {
+                        self.isLoading = false
+
+                        if let success = decoded.success {
                             self.createdGoalId = success.goalId
                             print("목표 생성 성공, goalId:", success.goalId)
+                            return
                         }
-                    } else {
-                        self.errorMessage = decoded.error?.reason ?? "목표 생성 실패"
-                        print("목표 생성 실패:", self.errorMessage ?? "")
+
+                        let reason = decoded.error?.reason ?? "목표 생성 실패"
+                        self.errorMessage = reason
+                        print("목표 생성 실패:", reason)
+
+                        // 서버가 200으로 FAIL 바디를 내려주는 경우 대비
+                        if reason.contains("이미 진행 중인 목표") {
+                            self.fetchCurrentGoal()
+                        }
                     }
                 } catch {
                     print("CreateGoal 디코딩 오류:", error)
+                    DispatchQueue.main.async {
+                        self.isLoading = false
+                        self.errorMessage = "CreateGoal 디코딩 오류"
+                    }
                 }
 
             case .failure(let error):
+                // 상태 변경은 메인으로
+                DispatchQueue.main.async {
+                    self.isLoading = false
+                }
+
+                // 409면 현재 목표 조회로 유도
+                if self.isHTTP409(error) {
+                    DispatchQueue.main.async {
+                        self.errorMessage = "이미 진행 중인 목표가 있어요. 기존 목표를 불러올게요."
+                    }
+                    self.fetchCurrentGoal()
+                    return
+                }
+
                 print("CreateGoal API 오류:", error)
+                DispatchQueue.main.async {
+                    self.errorMessage = "네트워크 오류가 발생했어요."
+                }
             }
         }
     }
-    
-    // 서버 전송용 날짜 포맷: "yyyy-MM-dd"
+
+    // MARK: - 현재 목표 조회 (GET /goals/current)
+    func fetchCurrentGoal() {
+        isLoading = true
+        errorMessage = nil
+        currentGoalId = nil
+
+        provider.request(.getCurrentGoal) { [weak self] result in
+            guard let self else { return }
+
+            switch result {
+            case .success(let response):
+                do {
+                    let decoded = try JSONDecoder().decode(GoalDetailResponse.self, from: response.data)
+
+                    DispatchQueue.main.async {
+                        self.isLoading = false
+
+                        if let goalId = decoded.success?.goalId {
+                            self.currentGoalId = goalId
+                            print("현재 목표 조회 성공, goalId:", goalId)
+                        } else {
+                            let reason = decoded.error?.reason ?? "현재 목표 조회 실패"
+                            self.errorMessage = reason
+                            print("현재 목표 조회 실패:", reason)
+                        }
+                    }
+                } catch {
+                    print("GoalDetail 디코딩 오류:", error)
+                    DispatchQueue.main.async {
+                        self.isLoading = false
+                        self.errorMessage = "현재 목표 디코딩 오류"
+                    }
+                }
+
+            case .failure(let error):
+                print("getCurrentGoal API 오류:", error)
+                DispatchQueue.main.async {
+                    self.isLoading = false
+                    self.errorMessage = "현재 목표 조회 네트워크 오류"
+                }
+            }
+        }
+    }
+
+    // MARK: - 서버 전송용 날짜 포맷: "yyyy-MM-dd"
     func formatDateForAPI(_ date: Date?) -> String {
         guard let date else { return "" }
 
@@ -89,22 +176,8 @@ final class OnboardingViewModel {
 
         return formatter.string(from: date)
     }
-    
-    
-    // MARK: - 유형별 비율 추천 목록 조회
-    
-    // 프리셋 선택
-    func selectPreset(_ preset: RatioPreset) {
-        selectedPresetId = preset.presetId
-        selectedPresetStep = preset.growthRatio / 10
-    }
-    
-    // 프리셋 선택했던 거 리셋
-    func clearSelectedPreset() {
-        selectedPresetId = nil
-        selectedPresetStep = nil
-    }
-    
+
+    // MARK: - 유형별 비율 추천 목록 조회 (GET /goals/ratio-presets)
     func fetchRatioPresets() {
         isLoading = true
         errorMessage = nil
@@ -112,36 +185,64 @@ final class OnboardingViewModel {
         provider.request(.getRatioList) { [weak self] result in
             guard let self else { return }
 
-            DispatchQueue.main.async {
-                self.isLoading = false
-            }
-
             switch result {
             case .success(let response):
                 do {
                     let decoded = try JSONDecoder().decode(RatioListResponse.self, from: response.data)
 
-                    if let success = decoded.success {
-                        DispatchQueue.main.async {
+                    DispatchQueue.main.async {
+                        self.isLoading = false
+
+                        if let success = decoded.success {
                             self.ratioPresets = success.presets
+                            print("비율 추천 목록 조회 성공:", success.presets.count)
+                        } else {
+                            let reason = decoded.error?.reason ?? "비율 추천 목록 조회 실패"
+                            self.errorMessage = reason
+                            print("비율 추천 목록 조회 실패:", reason)
                         }
-                        print("비율 추천 목록 조회 성공:", success.presets.count)
-                    } else {
-                        DispatchQueue.main.async {
-                            self.errorMessage = decoded.error?.reason ?? "비율 추천 목록 조회 실패"
-                        }
-                        print("비율 추천 목록 조회 실패:", self.errorMessage ?? "")
                     }
                 } catch {
                     print("RatioList 디코딩 오류:", error)
+                    DispatchQueue.main.async {
+                        self.isLoading = false
+                        self.errorMessage = "RatioList 디코딩 오류"
+                    }
                 }
 
             case .failure(let error):
+                print("RatioList API 오류:", error)
                 DispatchQueue.main.async {
+                    self.isLoading = false
                     self.errorMessage = "네트워크 오류가 발생했어요."
                 }
-                print("RatioList API 오류:", error)
             }
         }
+    }
+
+    // MARK: - 프리셋 선택
+    func selectPreset(_ preset: RatioPreset) {
+        selectedPresetId = preset.presetId
+        selectedPresetStep = preset.growthRatio / 10
+    }
+
+    func clearSelectedPreset() {
+        selectedPresetId = nil
+        selectedPresetStep = nil
+    }
+
+    // MARK: - Helpers
+    private func isHTTP409(_ error: MoyaError) -> Bool {
+        // 1) response가 있으면 여기로 가장 깔끔하게 체크 가능
+        if let response = error.response, response.statusCode == 409 {
+            return true
+        }
+
+        // 2) underlying에 response가 같이 붙는 케이스
+        if case let .underlying(_, response) = error, response?.statusCode == 409 {
+            return true
+        }
+
+        return false
     }
 }


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #46 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
* 로그인 -> 목표 설정 온보딩 -> 캘린더 -> 관심 분야 선택 -> 메인\
으로 가도록 화면 전환 구현했습니다.

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!
* 현재 로그인한 사용자가 기존 목표가 있을 경우, 온보딩 화면에서 "기존 목표가 있어 목표 설정이 안된다"는 에러가 뜹니다
* 테스트를 위해 이 에러가 떠도 화면 전환이 되도록 구현했습니다.
* 원활한 테스트를 위해 백엔드분께 사용자의 목표를 삭제할 수 있는 API를 만들어달라고 요청드린 상태입니다.
* 추후에 로그인한 사용자가 이미 목표 설정을 해둔 상태라면 바로 메인으로 가도록 수정하겠습니다.

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
![일단 로그인 -  온보딩 -  메인](https://github.com/user-attachments/assets/a1a062de-7361-4ac1-a90b-e265f17854f7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 온보딩 프로세스에 캘린더 단계 추가
  * 목표 설정 시 비율 프리셋 지원으로 더 편한 목표 생성
  * 목표 생성 완료 후 캘린더 화면으로 자동 이동

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
위 영상에서 그라데이션이 끊겨보이는데 실제로는 그라데이션 잘 되어 있습니다..!