### PR TITLE
[Feat] 일정 API 연동, 캘린더 조회 API 수정

### DIFF
--- a/Planvas/Planvas/Features/Calendar/Model/Event.swift
+++ b/Planvas/Planvas/Features/Calendar/Model/Event.swift
@@ -94,9 +94,18 @@ struct Event: Identifiable, Codable {
     /// 반복 타입 (repeatOption과 동일, 호환용)
     var repeatType: RepeatType? { get { repeatOption } set { repeatOption = newValue } }
 
-    /// 표시용 시간 문자열 (목록 등): "14:00 - 17:00" 또는 "하루종일"
+    /// 표시용 시간 문자열 (목록 등): "14:00 - 17:00", "2/15 18:45 - 2/16 19:30", 또는 "하루종일"
     var time: String {
         if isAllDay { return "하루종일" }
+        let cal = Calendar.current
+        if !cal.isDate(startDate, inSameDayAs: endDate) {
+            // 멀티데이: "2/15 18:45 - 2/16 19:30"
+            let sm = cal.component(.month, from: startDate)
+            let sd = cal.component(.day, from: startDate)
+            let em = cal.component(.month, from: endDate)
+            let ed = cal.component(.day, from: endDate)
+            return "\(sm)/\(sd) \(startTime.formatted) - \(em)/\(ed) \(endTime.formatted)"
+        }
         return "\(startTime.formatted) - \(endTime.formatted)"
     }
 

--- a/Planvas/Planvas/Features/Calendar/Repository/CalendarAPIRepository.swift
+++ b/Planvas/Planvas/Features/Calendar/Repository/CalendarAPIRepository.swift
@@ -53,19 +53,27 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
         }
     }
 
-    /// 일정 추가 (API 완성 후 재연결 예정)
+    /// 일정 추가 (POST /api/calendar/event)
     func addEvent(_ event: Event) async throws {
-        throw CalendarRepositoryError.notImplemented(message: "일정 추가 API 연동 예정")
+        let (startAt, endAt) = formatEventTimes(event)
+        _ = try await networkService.createEvent(title: event.title, startAt: startAt, endAt: endAt, type: "FIXED")
     }
 
-    /// 일정 수정 (API 완성 후 재연결 예정)
+    /// 일정 수정 (PATCH /api/calendar/event/{id})
     func updateEvent(_ event: Event) async throws {
-        throw CalendarRepositoryError.notImplemented(message: "일정 수정 API 연동 예정")
+        guard let serverId = event.fixedScheduleId ?? event.myActivityId else {
+            throw CalendarRepositoryError.missingServerId(message: "서버 일정 ID가 없어 수정할 수 없습니다.")
+        }
+        let (startAt, endAt) = formatEventTimes(event)
+        try await networkService.updateEvent(id: serverId, title: event.title, startAt: startAt, endAt: endAt, type: "FIXED")
     }
 
-    /// 일정 삭제 (API 완성 후 재연결 예정)
+    /// 일정 삭제 (DELETE /api/calendar/event/{id})
     func deleteEvent(_ event: Event) async throws {
-        throw CalendarRepositoryError.notImplemented(message: "일정 삭제 API 연동 예정")
+        guard let serverId = event.fixedScheduleId ?? event.myActivityId else {
+            throw CalendarRepositoryError.missingServerId(message: "서버 일정 ID가 없어 삭제할 수 없습니다.")
+        }
+        try await networkService.deleteEvent(id: serverId)
     }
 
     /// 구글 캘린더에서 가져올 수 있는 일정 목록 (GET events → ImportableSchedule, 일정 선택 화면용)
@@ -134,59 +142,77 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
         return serverEventColorPalette[safeIndex]
     }
 
-    /// 일간 일정 DTO → 캘린더 표시용 Event (날짜+시간 조합, 서버 ID 매핑).
-    /// API는 startDateTime/endDateTime(ISO8601) 또는 date+startTime/endTime(시:분)으로 옴. 종일이면 "하루종일" 표시.
+    /// 일간 일정 DTO → 캘린더 표시용 Event (api.md 기준: itemId String, startAt/endAt ISO, eventColor)
     private func mapToEvent(item: CalendarItemDTO, date: String) -> Event {
-        let isFixed = item.type == "FIXED"
-        let serverId = item.itemId
+        let isFixed = item.isFixed ?? (item.type == "FIXED")
+        let serverIdInt = Int(item.itemId)
         let id = Self.stableUUID(from: "\(item.type)-\(item.itemId)")
 
         let (startDate, endDate, startTime, endTime, isAllDay): (Date, Date, Time, Time, Bool)
-        if let startDt = item.startDateTime, let endDt = item.endDateTime,
+        if let startDt = item.startAt, let endDt = item.endAt,
            !startDt.isEmpty, !endDt.isEmpty,
-           let start = parseDayDateTimeAsLocal(startDt), let end = parseDayDateTimeAsLocal(endDt) {
-            let allDay = isAllDayEvent(start: start, end: end)
-            let startDay = calendar.startOfDay(for: start)
-            let endDay = calendar.startOfDay(for: end)
-            (startDate, endDate, startTime, endTime, isAllDay) = (
-                startDay,
-                endDay,
-                allDay ? .midnight : Time(from: start, calendar: calendar),
-                allDay ? .endOfDay : Time(from: end, calendar: calendar),
-                allDay
-            )
+           let start = parseISO8601Date(startDt), let end = parseISO8601Date(endDt) {
+
+            // 1) UTC 하루종일 패턴 감지: start=00:00Z, end=23:59Z → UTC 날짜를 로컬 날짜로 변환
+            let utcCal = Self.utcCalendar
+            let isUTCAllDay = utcCal.component(.hour, from: start) == 0
+                && utcCal.component(.minute, from: start) == 0
+                && utcCal.component(.hour, from: end) == 23
+                && utcCal.component(.minute, from: end) >= 59
+
+            if isUTCAllDay {
+                // UTC 날짜 숫자를 로컬 캘린더에 그대로 적용 (2/2 UTC → 2/2 로컬)
+                let startComps = utcCal.dateComponents([.year, .month, .day], from: start)
+                let endComps = utcCal.dateComponents([.year, .month, .day], from: end)
+                let localStart = calendar.date(from: startComps).flatMap { calendar.startOfDay(for: $0) }
+                    ?? calendar.startOfDay(for: start)
+                let localEnd = calendar.date(from: endComps).flatMap { calendar.startOfDay(for: $0) }
+                    ?? calendar.startOfDay(for: end)
+                (startDate, endDate, startTime, endTime, isAllDay) = (
+                    localStart, localEnd, .midnight, .endOfDay, true
+                )
+            } else {
+                // 2) 로컬 시간 기준 하루종일 감지 (기존 +09:00 형식으로 저장된 일정 호환)
+                let allDay = isAllDayEvent(start: start, end: end)
+                let startDay = calendar.startOfDay(for: start)
+                let endDay = calendar.startOfDay(for: end)
+                (startDate, endDate, startTime, endTime, isAllDay) = (
+                    startDay,
+                    endDay,
+                    allDay ? .midnight : Time(from: start, calendar: calendar),
+                    allDay ? .endOfDay : Time(from: end, calendar: calendar),
+                    allDay
+                )
+            }
         } else {
-            let st = item.startTime ?? ""
-            let et = item.endTime ?? ""
-            let (s, e) = parseDayTime(date: date, startTime: st, endTime: et)
-            let allDay = st.isEmpty && et.isEmpty
-            let startDay = calendar.startOfDay(for: s)
-            let endDay = calendar.startOfDay(for: e)
+            // startAt/endAt 없으면 해당 날짜의 종일 일정으로 처리
+            let day = Self.dateOnlyFormatter.date(from: date) ?? Date()
+            let startDay = calendar.startOfDay(for: day)
+            let endDay = startDay
             (startDate, endDate, startTime, endTime, isAllDay) = (
-                startDay,
-                endDay,
-                allDay ? .midnight : Time(from: s, calendar: calendar),
-                allDay ? .endOfDay : Time(from: e, calendar: calendar),
-                allDay
+                startDay, endDay, .midnight, .endOfDay, true
             )
         }
+
+        let color: EventColorType = item.eventColor.map { EventColorType.from(serverColor: $0) }
+            ?? (isFixed ? .purple1 : Self.colorForServerItem(type: item.type, itemId: item.itemId))
 
         return Event(
             id: id,
             title: item.title,
             isFixed: isFixed,
             isAllDay: isAllDay,
-            color: isFixed ? .purple1 : Self.colorForServerItem(type: item.type, itemId: "\(item.itemId)"),
+            color: color,
             type: isFixed ? .fixed : .activity,
             startDate: startDate,
             endDate: endDate,
             startTime: startTime,
             endTime: endTime,
             category: .none,
-            isCompleted: item.completed ?? false,
-            isRepeating: isFixed,
-            fixedScheduleId: isFixed ? serverId : nil,
-            myActivityId: isFixed ? nil : serverId
+            isCompleted: false,
+            isRepeating: false,
+            fixedScheduleId: isFixed ? serverIdInt : nil,
+            myActivityId: isFixed ? nil : serverIdInt
         )
     }
 
@@ -195,10 +221,11 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
         let startOfDay = calendar.startOfDay(for: start)
         let isStartMidnight = start.timeIntervalSince(startOfDay) < 60
         guard isStartMidnight else { return false }
-        let endOfDay = calendar.date(bySettingHour: 23, minute: 59, second: 59, of: start) ?? start
+        // 종료가 같은 날 23:59(:00 이상) 이거나 다음날 자정 부근(±60초)이면 종일
+        let endOfDay = calendar.date(bySettingHour: 23, minute: 59, second: 0, of: start) ?? start
         let nextDayStart = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? start
         let isEndSameDayEOD = calendar.isDate(end, inSameDayAs: start) && end >= endOfDay
-        let isEndNextDayStart = abs(end.timeIntervalSince(nextDayStart)) < 60
+        let isEndNextDayStart = abs(end.timeIntervalSince(nextDayStart)) <= 60
         return isEndSameDayEOD || isEndNextDayStart
     }
 
@@ -215,6 +242,58 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
         bytes[8] = (bytes[8] & 0x3F) | 0x80  // variant RFC 4122
         return UUID(uuid: (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]))
     }
+
+    // MARK: - Event → ISO 변환 (일정 추가/수정 요청용)
+
+    /// Event의 isAllDay 여부에 따라 ISO 문자열 포맷을 분기.
+    /// - 하루종일: UTC 자정 기준으로 전송 ("2026-02-02T00:00:00Z" ~ "2026-02-02T23:59:00Z")
+    ///   → 서버가 UTC 날짜로 매칭하므로 날짜가 밀리지 않음
+    /// - 일반: 로컬 타임존 포함 ("2026-02-02T18:21:00+09:00")
+    private func formatEventTimes(_ event: Event) -> (startAt: String, endAt: String) {
+        if event.isAllDay {
+            // 로컬 날짜의 year/month/day를 UTC 자정으로 변환
+            let startComps = calendar.dateComponents([.year, .month, .day], from: event.startDate)
+            let endComps = calendar.dateComponents([.year, .month, .day], from: event.endDate)
+            guard let utcStart = Self.utcCalendar.date(from: startComps),
+                  let utcEndDay = Self.utcCalendar.date(from: endComps),
+                  let utcEnd = Self.utcCalendar.date(bySettingHour: 23, minute: 59, second: 0, of: utcEndDay) else {
+                // fallback: 로컬 포맷
+                return (formatToISO(event.startDateTime()), formatToISO(event.endDateTime()))
+            }
+            return (Self.utcISO8601Formatter.string(from: utcStart),
+                    Self.utcISO8601Formatter.string(from: utcEnd))
+        } else {
+            return (formatToISO(event.startDateTime()), formatToISO(event.endDateTime()))
+        }
+    }
+
+    /// Date → "2026-02-12T18:10:00+09:00" (로컬 타임존 포함 ISO 8601)
+    private func formatToISO(_ date: Date) -> String {
+        Self.localISO8601Formatter.string(from: date)
+    }
+
+    private static let localISO8601Formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXX"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f
+    }()
+
+    /// UTC ISO 8601 포맷터 (하루종일 일정 전송용)
+    private static let utcISO8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        f.timeZone = TimeZone(identifier: "UTC")!
+        return f
+    }()
+
+    /// UTC 기준 Calendar (하루종일 날짜 변환용)
+    private static let utcCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
 
     // MARK: - Formatters (일간 조회·구글 일정 매핑용)
 
@@ -271,50 +350,6 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
         if let d = Self.iso8601WithFraction.date(from: string) { return d }
         if let d = Self.iso8601NoFraction.date(from: string) { return d }
         return Self.dateOnlyFormatter.date(from: string)
-    }
-
-    /// 일간 API startAt/endAt: 서버가 로컬 시간을 Z로 보내는 경우를 위해, 날짜·시간을 로컬 타임존으로 해석.
-    /// (예: "2026-02-19T16:10:00.000Z" → 16:10 로컬, UTC로 해석하면 KST에서 01:10으로 나옴)
-    private static let dayDateTimeAsLocalFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-        f.timeZone = TimeZone.current
-        f.locale = Locale(identifier: "en_US_POSIX")
-        return f
-    }()
-
-    private static let dayDateTimeAsLocalFormatterNoFraction: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        f.timeZone = TimeZone.current
-        f.locale = Locale(identifier: "en_US_POSIX")
-        return f
-    }()
-
-    private func parseDayDateTimeAsLocal(_ string: String) -> Date? {
-        guard !string.isEmpty else { return nil }
-        if let d = Self.dayDateTimeAsLocalFormatter.date(from: string) { return d }
-        return Self.dayDateTimeAsLocalFormatterNoFraction.date(from: string)
-    }
-
-    /// "yyyy-MM-dd" + "HH:mm" 조합으로 해당 날짜의 시작/종료 Date 생성 (종일이면 00:00~다음날 00:00)
-    private func parseDayTime(date: String, startTime: String, endTime: String) -> (Date, Date) {
-        let day = Self.dateOnlyFormatter.date(from: date) ?? Date()
-        if startTime.isEmpty && endTime.isEmpty {
-            let start = calendar.startOfDay(for: day)
-            let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
-            return (start, end)
-        }
-        let start = combine(date: day, time: startTime, formatter: Self.timeFormatter) ?? day
-        let end = combine(date: day, time: endTime, formatter: Self.timeFormatter) ?? day
-        return (start, end)
-    }
-
-    /// 날짜에 시:분 적용해 하나의 Date 반환
-    private func combine(date: Date, time: String, formatter: DateFormatter) -> Date? {
-        guard let t = formatter.date(from: time) else { return nil }
-        let comps = calendar.dateComponents([.hour, .minute], from: t)
-        return calendar.date(bySettingHour: comps.hour ?? 0, minute: comps.minute ?? 0, second: 0, of: date)
     }
 
     /// Date → "yyyy-MM-dd" (API 쿼리/키용)

--- a/Planvas/Planvas/Features/Calendar/Repository/CalendarRepository.swift
+++ b/Planvas/Planvas/Features/Calendar/Repository/CalendarRepository.swift
@@ -123,14 +123,15 @@ final class CalendarRepository: CalendarRepositoryProtocol {
                 date: dateStr,
                 hasItems: hasKey,
                 itemCount: list.count,
-                schedulesPreview: list.prefix(3).map { CalendarRepository.preview(from: $0, itemId: abs($0.id.hashValue) % 1_000_000) }
+                schedulesPreview: list.prefix(3).map { CalendarRepository.preview(from: $0, itemId: "\(abs($0.id.hashValue) % 1_000_000)") },
+                moreCount: max(list.count - 3, 0)
             )
         }
         return MonthlyCalendarSuccessDTO(year: year, month: month, days: days)
     }
 
-    private static func preview(from event: Event, itemId: Int) -> SchedulePreviewDTO {
-        SchedulePreviewDTO(itemId: itemId, title: event.title, isFixed: event.isFixed, isRepeating: event.isRepeating, type: "MANUAL", color: event.color.serverColor)
+    private static func preview(from event: Event, itemId: String) -> SchedulePreviewDTO {
+        SchedulePreviewDTO(itemId: itemId, title: event.title, isFixed: event.isFixed, type: "FIXED", eventColor: event.color.serverColor)
     }
     
     func getEvents(for date: Date) async throws -> [Event] {

--- a/Planvas/Planvas/Features/Calendar/View/CalendarView.swift
+++ b/Planvas/Planvas/Features/Calendar/View/CalendarView.swift
@@ -320,7 +320,7 @@ struct CalendarView: View {
         let isToday = viewModel.isDateToday(date)
         let displayEvents = viewModel.getDisplayEvents(for: date, isSelected: isSelected)
         let repeatingEvents = viewModel.getRepeatingEvents(for: date)
-        let multiDaySegments = viewModel.getMultiDayEventSegments(for: date)
+        let multiDayBarLayout = viewModel.getMultiDayBarLayout(for: date)
         
         let dateTextColor = dayTextColor(isSelected: isSelected, isCurrentMonth: isCurrentMonth)
         
@@ -356,38 +356,48 @@ struct CalendarView: View {
                     }
                 }
                 
-                // 여러 날에 걸친 이벤트 막대 (날짜 바로 아래)
-                if isCurrentMonth && !multiDaySegments.isEmpty {
+                // 여러 날에 걸친 이벤트 막대 + 하루 단위 이벤트 (합계 최대 3개)
+                let multiDaySlotCount = multiDayBarLayout.count
+                let remainingForSingle = max(0, 3 - multiDaySlotCount)
+                let limitedDisplayEvents = Array(displayEvents.prefix(remainingForSingle))
+
+                if isCurrentMonth && !multiDayBarLayout.isEmpty {
                     VStack(spacing: 2) {
-                        ForEach(Array(multiDaySegments.prefix(2).enumerated()), id: \.element.event.id) { _, segment in
-                            multiDayBarSegment(
-                                event: segment.event,
-                                isStart: segment.isStart,
-                                isEnd: segment.isEnd,
-                                isSelected: isSelected
-                            )
+                        ForEach(multiDayBarLayout) { slot in
+                            if let event = slot.event {
+                                multiDayBarSegment(
+                                    event: event,
+                                    isStart: slot.isStart,
+                                    isEnd: slot.isEnd,
+                                    isSelected: isSelected
+                                )
+                            } else {
+                                // 빈 슬롯: 투명 스페이서로 자리 유지
+                                Color.clear
+                                    .frame(height: 11)
+                            }
                         }
                     }
                     .padding(.top, 2)
                 }
-                
-                // 이벤트 표시 영역 (하루 단위만)
+
+                // 이벤트 표시 영역 (하루 단위만, 멀티데이 막대와 합계 3개 이내)
                 VStack(spacing: 2) {
-                    if !displayEvents.isEmpty && isCurrentMonth {
-                        ForEach(displayEvents) { event in
+                    if !limitedDisplayEvents.isEmpty && isCurrentMonth {
+                        ForEach(limitedDisplayEvents) { event in
                             HStack(spacing: 3) {
                                 Rectangle()
                                     .foregroundColor(event.color.uiColor)
                                     .frame(width: 2.5, height: 9)
                                     .cornerRadius(1.25)
-                                
+
                                 Text(event.title)
                                     .textStyle(.medium10)
                                     .foregroundColor(isSelected ? .white : .black1)
                                     .lineLimit(1)
                                     .truncationMode(.tail)
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                
+
                                 Spacer(minLength: 0)
                             }
                             .frame(maxWidth: .infinity)
@@ -401,6 +411,7 @@ struct CalendarView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         }
         .frame(height: 79)
+        .clipped()
         .contentShape(Rectangle())
         .onTapGesture {
             viewModel.selectDate(date)
@@ -417,11 +428,9 @@ struct CalendarView: View {
                 .padding(.top, 12)
                 .padding(.bottom, 20)
             
-            // 이벤트 카드들
+            // 이벤트 카드들 (일간 조회 결과)
             VStack(spacing: 12) {
-                let events = viewModel.getEvents(for: viewModel.selectedDate)
-                
-                ForEach(events) { event in
+                ForEach(viewModel.selectedDateEvents) { event in
                     eventCardView(event: event)
                 }
                 
@@ -456,22 +465,6 @@ struct CalendarView: View {
                 }
                 
                 Spacer()
-                
-                if event.isFixed {
-                    Text("고정")
-                        .textStyle(.semibold14spacing)
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background(
-                            LinearGradient(
-                                colors: [.gradprimary1, .primary1],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            )
-                        )
-                        .cornerRadius(20)
-                }
             }
             .padding(16)
             .background(Color.white)

--- a/Planvas/Planvas/Features/Calendar/ViewModel/CalendarViewModel.swift
+++ b/Planvas/Planvas/Features/Calendar/ViewModel/CalendarViewModel.swift
@@ -26,8 +26,10 @@ final class CalendarViewModel {
 
     /// 월간 API 결과 (날짜별 메타·프리뷰). 그리드 표시용.
     private(set) var monthData: MonthlyCalendarSuccessDTO?
-    /// 날짜 클릭 시 로드한 상세 일정 (날짜 키 → Event[])
+    /// 월간 프리뷰 기반 Event (그리드 표시 전용, 일간 조회로 덮어쓰지 않음)
     private(set) var sampleEvents: [String: [Event]] = [:]
+    /// 선택된 날짜의 일간 조회 결과 (목록 표시 전용)
+    private(set) var selectedDateEvents: [Event] = []
 
     /// Google 캘린더 연동 여부 (Repository 연동 상태에서 로드)
     private(set) var isCalendarConnected: Bool = false
@@ -93,12 +95,10 @@ final class CalendarViewModel {
     }
     
     // MARK: - Methods
-    /// 그 날짜의 일정. 먼저 sampleEvents(상세 로드분), 없으면 월간 프리뷰로 표시.
+    /// 그 날짜의 일정. sampleEvents(월간 프리뷰 + 일간 상세 캐시)에서 반환.
     func getEvents(for date: Date) -> [Event] {
         let dateKey = dateKeyString(from: date)
-        if let loaded = sampleEvents[dateKey], !loaded.isEmpty { return loaded }
-        guard let day = monthData?.days.first(where: { $0.date == dateKey }) else { return [] }
-        return day.schedulesPreview.prefix(3).map { eventFromPreview($0, date: date) }
+        return sampleEvents[dateKey] ?? []
     }
     
     /// 그 날짜의 이벤트 이름 표시용 (바 + 일정 이름). 고정+반복만 점으로 표시하므로 제외. 멀티데이 활동은 종료일에만 여기서 표시.
@@ -128,6 +128,111 @@ final class CalendarViewModel {
                 return (event, isStart, isEnd)
             }
     }
+
+    // MARK: - 멀티데이 막대 슬롯 레이아웃 (주 단위 일관성)
+
+    /// 한 날짜의 멀티데이 막대 슬롯 배열. nil = 빈 슬롯(스페이서), non-nil = 막대 표시.
+    struct MultiDayBarSlot: Identifiable {
+        let id: String
+        let event: Event?
+        let isStart: Bool
+        let isEnd: Bool
+    }
+
+    /// 주 단위로 슬롯을 배정하여, 같은 이벤트가 주 내에서 항상 같은 줄에 표시되도록 함.
+    /// - 주의 모든 멀티데이 이벤트를 시작일 기준으로 정렬
+    /// - 각 이벤트에 가장 낮은 빈 슬롯 배정
+    /// - 해당 날짜의 슬롯 배열 반환 (빈 슬롯은 nil 이벤트)
+    func getMultiDayBarLayout(for date: Date) -> [MultiDayBarSlot] {
+        // 1. 이 날짜가 속한 주의 시작일 (일요일) 찾기
+        let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date))
+            ?? date
+
+        // 2. 주의 7일 동안 모든 멀티데이 이벤트 수집 (중복 제거)
+        var seenIds = Set<UUID>()
+        var weekEvents: [Event] = []
+        for offset in 0..<7 {
+            guard let day = calendar.date(byAdding: .day, value: offset, to: weekStart) else { continue }
+            for event in getEvents(for: day) {
+                guard event.isFixed && !event.isRepeating else { continue }
+                guard !calendar.isDate(event.startDate, inSameDayAs: event.endDate) else { continue }
+                if seenIds.insert(event.id).inserted {
+                    weekEvents.append(event)
+                }
+            }
+        }
+
+        // 3. 시작일 빠른 순 → 같으면 종료일 늦는 순 (긴 일정 우선)
+        weekEvents.sort {
+            if !calendar.isDate($0.startDate, inSameDayAs: $1.startDate) {
+                return $0.startDate < $1.startDate
+            }
+            return $0.endDate > $1.endDate
+        }
+
+        // 4. 각 이벤트에 슬롯 배정 (그리디: 가장 낮은 빈 슬롯)
+        //    slotEndDates[slot] = 해당 슬롯이 점유된 마지막 날짜
+        var slotEndDates: [Date] = []
+        var eventSlot: [UUID: Int] = [:]
+
+        for event in weekEvents {
+            let evStart = calendar.startOfDay(for: event.startDate)
+            var assigned = false
+            for slot in 0..<slotEndDates.count {
+                // 슬롯의 마지막 점유일 다음날부터 비어있으면 사용 가능
+                if evStart > slotEndDates[slot] {
+                    slotEndDates[slot] = calendar.startOfDay(for: event.endDate)
+                    eventSlot[event.id] = slot
+                    assigned = true
+                    break
+                }
+            }
+            if !assigned {
+                let newSlot = slotEndDates.count
+                slotEndDates.append(calendar.startOfDay(for: event.endDate))
+                eventSlot[event.id] = newSlot
+            }
+        }
+
+        let totalSlots = slotEndDates.count
+        guard totalSlots > 0 else { return [] }
+
+        // 5. 이 날짜에 해당하는 슬롯 배열 생성
+        let dayStart = calendar.startOfDay(for: date)
+        var slots = [MultiDayBarSlot]()
+
+        for slot in 0..<min(totalSlots, 2) { // 최대 2줄
+            // 이 슬롯에 이 날짜에 표시할 이벤트 찾기
+            let matchingEvent = weekEvents.first { event in
+                guard eventSlot[event.id] == slot else { return false }
+                let evStart = calendar.startOfDay(for: event.startDate)
+                let evEnd = calendar.startOfDay(for: event.endDate)
+                return dayStart >= evStart && dayStart <= evEnd
+            }
+
+            if let event = matchingEvent {
+                let isStart = calendar.isDate(date, inSameDayAs: event.startDate)
+                let isEnd = calendar.isDate(date, inSameDayAs: event.endDate)
+                slots.append(MultiDayBarSlot(
+                    id: "slot-\(slot)-\(event.id)",
+                    event: event,
+                    isStart: isStart,
+                    isEnd: isEnd
+                ))
+            } else {
+                // 빈 슬롯 (스페이서로 자리 유지)
+                slots.append(MultiDayBarSlot(
+                    id: "slot-\(slot)-empty-\(dateKeyString(from: date))",
+                    event: nil,
+                    isStart: false,
+                    isEnd: false
+                ))
+            }
+        }
+
+        // 빈 슬롯만 있으면 빈 배열 반환
+        return slots.contains(where: { $0.event != nil }) ? slots : []
+    }
     
     /// 하루 단위 이벤트만 (멀티데이 제외, 리스트 표시용)
     private func getSingleDayEvents(for date: Date) -> [Event] {
@@ -136,13 +241,17 @@ final class CalendarViewModel {
     }
     
     func hasEvents(for date: Date) -> Bool {
-        return !getEvents(for: date).isEmpty
+        let dateKey = dateKeyString(from: date)
+        if let events = sampleEvents[dateKey], !events.isEmpty { return true }
+        // sampleEvents에 없더라도 monthData에 hasItems가 true면 일정이 있는 것
+        return monthData?.days.first(where: { $0.date == dateKey })?.hasItems ?? false
     }
     
     func selectDate(_ date: Date) {
         let isCurrentMonth = calendar.isDate(date, equalTo: currentMonth, toGranularity: .month)
         if isCurrentMonth {
             selectedDate = date
+            Task { await loadEventsForDate(date) }
         }
     }
     
@@ -219,7 +328,7 @@ final class CalendarViewModel {
     }
     
     func deleteEvent(_ event: Event) {
-        // 낙관적 업데이트: id 기준으로 모든 날짜에서 제거 (멀티데이 일정 전체 삭제)
+        // 낙관적 업데이트: id 기준으로 모든 날짜에서 제거
         var newEvents = sampleEvents
         for dateKey in Array(newEvents.keys) {
             var list = newEvents[dateKey] ?? []
@@ -235,9 +344,10 @@ final class CalendarViewModel {
         Task {
             do {
                 try await repository.deleteEvent(event)
+                await refreshEvents()
             } catch {
-                // 서버 오류가 나더라도 로컬에서는 삭제된 상태 유지 (되돌리지 않음)
                 print("이벤트 삭제 실패: \(error)")
+                await refreshEvents()
             }
         }
     }
@@ -266,10 +376,10 @@ final class CalendarViewModel {
         Task {
             do {
                 try await repository.updateEvent(event)
+                await refreshEvents()
             } catch {
-                // API 연동 전까지 롤백 비활성화. notImplemented 등 실패 시에도 낙관적 업데이트 유지.
-                // applyEventsFromRepository() 호출 시 refreshEvents()로 서버 데이터가 로컬을 덮어써 수정 내용이 사라짐.
                 print("이벤트 수정 실패: \(error)")
+                await refreshEvents()
             }
         }
     }
@@ -382,7 +492,7 @@ final class CalendarViewModel {
     }
     
     func addEvent(_ event: Event) {
-        // 반복: 시작일~종료일만. 비반복: 시작일~종료일.
+        // 낙관적 업데이트
         let keysToAdd = event.isRepeating
             ? dateKeysForRepeatingEvent(event)
             : dateKeys(from: event.startDate, to: event.endDate)
@@ -396,9 +506,10 @@ final class CalendarViewModel {
         Task {
             do {
                 try await repository.addEvent(event)
+                await refreshEvents()
             } catch {
-                // 서버 오류 시에도 낙관적 반영은 유지 (사용자에게는 저장된 것처럼 보이게 함). 필요 시 백그라운드 재시도/토스트는 별도 구현.
-                print("이벤트 추가 서버 오류 (로컬에는 유지): \(error)")
+                print("이벤트 추가 서버 오류: \(error)")
+                await refreshEvents()
             }
         }
     }
@@ -419,44 +530,102 @@ final class CalendarViewModel {
         }
     }
     
-    /// 월간 API 호출 후, 해당 월 전체 일정을 일간 조회로 불러와 그리드에 바로 표시 (날짜 클릭 없이도 이벤트 표시)
+    /// 월간 API만 호출하여 그리드 표시용 데이터를 갱신. 상세 일정은 날짜 클릭(일간 조회) 시 로드.
     func refreshEvents() async {
         let year = calendar.component(.year, from: currentMonth)
         let month = calendar.component(.month, from: currentMonth)
-        guard let firstDay = calendar.date(from: DateComponents(year: year, month: month, day: 1)),
-              let range = calendar.range(of: .day, in: .month, for: firstDay),
-              let lastDay = calendar.date(byAdding: .day, value: range.count - 1, to: firstDay) else {
-            return
-        }
         do {
             let monthResult = try await repository.getMonthCalendar(year: year, month: month)
             monthData = monthResult
-            let rawEvents = try await repository.getEvents(from: firstDay, to: lastDay)
-            let uniqueEvents = deduplicateMultiDayEvents(rawEvents)
-            let fetchedByDate = eventsToDictionary(uniqueEvents)
-            var next = sampleEvents
-            for (key, list) in fetchedByDate {
-                next[key] = list
-            }
-            sampleEvents = next
+            // 월간 프리뷰에서 멀티데이 감지하여 Event로 변환 → sampleEvents에 반영
+            buildMonthPreviewEvents()
+            // 현재 선택된 날짜의 일간 조회도 자동 로드 (시간 정보 포함)
+            await loadEventsForDate(selectedDate)
         } catch {
             print("월간 캘린더 조회 실패: \(error)")
         }
     }
 
-    /// 해당 날짜 상세 일정 로드 (GET /api/calendar/day) 후 sampleEvents에 반영.
-    /// 딕셔너리 전체를 새로 할당해 @Observable이 변경을 감지하도록 함 (시간 정보가 반영된 목록이 UI에 표시됨).
+    /// 월간 프리뷰에서 같은 itemId가 여러 날에 있으면 멀티데이 Event로 변환, sampleEvents에 반영.
+    /// 날짜 클릭(일간 조회) 시 해당 날짜만 덮어쓰므로, 나머지 날짜에는 프리뷰 기반 Event가 유지됨.
+    private func buildMonthPreviewEvents() {
+        guard let monthData = monthData else { return }
+
+        // 1. 모든 날짜의 프리뷰를 itemId로 그룹핑
+        var itemDates: [String: [String]] = [:]          // itemId → [date strings]
+        var itemPreview: [String: SchedulePreviewDTO] = [:] // itemId → 대표 preview
+
+        for day in monthData.days {
+            for preview in day.schedulesPreview {
+                if itemDates[preview.itemId] == nil {
+                    itemDates[preview.itemId] = []
+                    itemPreview[preview.itemId] = preview
+                }
+                itemDates[preview.itemId]?.append(day.date)
+            }
+        }
+
+        // 2. 각 itemId에 대해 Event 생성 (멀티데이 여부 자동 감지)
+        var events: [String: [Event]] = [:]
+
+        for (itemId, dates) in itemDates {
+            guard let preview = itemPreview[itemId] else { continue }
+            let sortedDates = dates.sorted()
+            guard let firstStr = sortedDates.first,
+                  let lastStr = sortedDates.last,
+                  let firstDate = Self.previewDateFormatter.date(from: firstStr),
+                  let lastDate = Self.previewDateFormatter.date(from: lastStr) else { continue }
+
+            let startDay = calendar.startOfDay(for: firstDate)
+            let isMultiDay = sortedDates.count > 1
+            let endDay = isMultiDay
+                ? calendar.startOfDay(for: lastDate)
+                : (calendar.date(bySettingHour: 23, minute: 59, second: 59, of: startDay) ?? startDay)
+
+            // 멀티데이: itemId만으로 UUID (모든 날에서 동일 Event)
+            // 싱글데이: 날짜 포함 UUID
+            let id = isMultiDay
+                ? CalendarViewModel.stableUUID(from: "preview-\(itemId)")
+                : CalendarViewModel.stableUUID(from: "preview-\(itemId)-\(sortedDates[0])")
+
+            let color: EventColorType = (preview.eventColor.map { EventColorType.from(serverColor: $0) })
+                ?? (preview.isFixed ? .purple1 : Self.colorForServerItem(itemId: itemId, type: preview.type))
+
+            let event = Event(
+                id: id,
+                title: preview.title,
+                isFixed: preview.isFixed,
+                isAllDay: true,
+                color: color,
+                type: preview.isFixed ? .fixed : .activity,
+                startDate: startDay,
+                endDate: endDay,
+                startTime: .midnight,
+                endTime: .endOfDay,
+                category: .none,
+                isCompleted: false,
+                isRepeating: false,
+                fixedScheduleId: Int(itemId)
+            )
+
+            // 해당 일정이 존재하는 모든 날짜에 추가
+            for dateStr in sortedDates {
+                if events[dateStr] == nil { events[dateStr] = [] }
+                events[dateStr]?.append(event)
+            }
+        }
+
+        sampleEvents = events
+    }
+
+    /// 해당 날짜 상세 일정 로드 (GET /api/calendar/day) → 목록 표시용 selectedDateEvents만 갱신.
+    /// 캘린더 그리드(sampleEvents)는 월간 프리뷰 데이터만 사용하므로 건드리지 않음.
     func loadEventsForDate(_ date: Date) async {
-        let dateKey = dateKeyString(from: date)
         do {
             let events = try await repository.getEvents(for: date)
-            var next = sampleEvents
-            next[dateKey] = events
-            sampleEvents = next
+            selectedDateEvents = events
         } catch {
-            var next = sampleEvents
-            next[dateKey] = []
-            sampleEvents = next
+            selectedDateEvents = []
         }
     }
     
@@ -494,30 +663,13 @@ final class CalendarViewModel {
     /// 서버에서 색을 주지 않을 때 사용하는 팔레트 (Repository와 동일한 순서로 동일 itemId → 동일 색)
     private static let serverEventColorPalette: [EventColorType] = [.purple2, .blue1, .red, .yellow, .blue2, .pink, .green, .blue3, .purple1]
 
-    /// 월간 API 프리뷰만 있을 때 그리드 표시용 Event 생성 (날짜 클릭 시 상세 로드로 대체됨)
-    /// endDate를 같은 날 23:59로 두어 getSingleDayEvents/이벤트 표시 영역에 포함되도록 함. 색은 API color(1~10) 우선.
-    private func eventFromPreview(_ preview: SchedulePreviewDTO, date: Date) -> Event {
-        let start = calendar.startOfDay(for: date)
-        let end = calendar.date(bySettingHour: 23, minute: 59, second: 59, of: date) ?? start
-        let id = CalendarViewModel.stableUUID(from: "preview-\(preview.itemId)-\(dateKeyString(from: date))")
-        let color: EventColorType = (preview.color.map { EventColorType.from(serverColor: $0) })
-            ?? (preview.isFixed ? .purple1 : Self.colorForServerItem(itemId: "\(preview.itemId)", type: preview.type))
-        return Event(
-            id: id,
-            title: preview.title,
-            isFixed: preview.isFixed,
-            isAllDay: true,
-            color: color,
-            type: preview.isFixed ? .fixed : .activity,
-            startDate: start,
-            endDate: end,
-            startTime: .midnight,
-            endTime: .endOfDay,
-            category: .none,
-            isCompleted: false,
-            isRepeating: preview.isRepeating
-        )
-    }
+    /// "yyyy-MM-dd" 문자열 → Date 변환 (월간 프리뷰 날짜 파싱용)
+    private static let previewDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
 
     private static func colorForServerItem(itemId: String, type: String) -> EventColorType {
         var data = Data()

--- a/Planvas/Planvas/Service/Calendar/CalendarAPI.swift
+++ b/Planvas/Planvas/Service/Calendar/CalendarAPI.swift
@@ -18,6 +18,9 @@ enum CalendarAPI {
     case getGoogleSchedulesCalendar(timeMin: String?, timeMax: String?) // 구글 캘린더 가져올 일정 목록 조회
     case getMonthCalendar(year: Int, month: Int) // 월간 캘린더 조회
     case getDateCalendar(date: String) // 일간 캘린더 조회 - (YYYY-MM-DD)형식 날짜 조회
+    case postEvent(body: CreateEventRequestDTO) // 일정 추가 POST /api/calendar/event
+    case patchEvent(id: Int, body: UpdateEventRequestDTO) // 일정 수정 PATCH /api/calendar/event/{id}
+    case deleteEvent(id: Int) // 일정 삭제 DELETE /api/calendar/event/{id}
 }
 
 extension CalendarAPI: APITargetType {
@@ -35,15 +38,25 @@ extension CalendarAPI: APITargetType {
             return "/api/calendar/month"
         case .getDateCalendar:
             return "/api/calendar/day"
+        case .postEvent:
+            return "/api/calendar/event"
+        case .patchEvent(let id, _):
+            return "/api/calendar/event/\(id)"
+        case .deleteEvent(let id):
+            return "/api/calendar/event/\(id)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .postGoogleCalendar, .postGoogleSchedulesCalendar:
+        case .postGoogleCalendar, .postGoogleSchedulesCalendar, .postEvent:
             return .post
         case .getGoogleCalendar, .getGoogleSchedulesCalendar, .getMonthCalendar, .getDateCalendar:
             return .get
+        case .patchEvent:
+            return .patch
+        case .deleteEvent:
+            return .delete
         }
     }
     
@@ -83,6 +96,12 @@ extension CalendarAPI: APITargetType {
                 parameters: ["date": date],
                 encoding: URLEncoding.queryString
             )
+        case .postEvent(let body):
+            return .requestJSONEncodable(body)
+        case .patchEvent(_, let body):
+            return .requestJSONEncodable(body)
+        case .deleteEvent:
+            return .requestPlain
         }
     }
 }

--- a/Planvas/Planvas/Service/Calendar/CalendarNetworkService.swift
+++ b/Planvas/Planvas/Service/Calendar/CalendarNetworkService.swift
@@ -82,6 +82,38 @@ final class CalendarNetworkService: @unchecked Sendable {
         return success
     }
 
+    // MARK: - 일정 추가/수정/삭제
+
+    /// 일정 추가 POST /api/calendar/event
+    func createEvent(title: String, startAt: String, endAt: String, type: String = "FIXED") async throws -> CreateEventSuccess {
+        let body = CreateEventRequestDTO(title: title, startAt: startAt, endAt: endAt, type: type)
+        let response: CreateEventResponse = try await request(.postEvent(body: body))
+        if let error = response.error {
+            throw CalendarAPIError.serverFail(reason: error.reason)
+        }
+        guard let success = response.success else {
+            throw CalendarAPIError.invalidResponse
+        }
+        return success
+    }
+
+    /// 일정 수정 PATCH /api/calendar/event/{id}
+    func updateEvent(id: Int, title: String, startAt: String, endAt: String, type: String = "FIXED") async throws {
+        let body = UpdateEventRequestDTO(title: title, startAt: startAt, endAt: endAt, type: type)
+        let response: UpdateEventResponse = try await request(.patchEvent(id: id, body: body))
+        if let error = response.error {
+            throw CalendarAPIError.serverFail(reason: error.reason)
+        }
+    }
+
+    /// 일정 삭제 DELETE /api/calendar/event/{id}
+    func deleteEvent(id: Int) async throws {
+        let response: DeleteEventResponse = try await request(.deleteEvent(id: id))
+        if let error = response.error {
+            throw CalendarAPIError.serverFail(reason: error.reason)
+        }
+    }
+
     // MARK: - Private
 
     private func request<T: Decodable>(_ target: CalendarAPI) async throws -> T {


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #93

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
- 일정 API 연동했습니다

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!
- 일정 색깔 지정, 반복 옵션의 경우 API 구현이 아직 안 됨

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
<img width="400" alt="Simulator Screenshot - iPhone 15 Pro - 2026-02-12 at 19 17 10" src="https://github.com/user-attachments/assets/72c27889-0d5e-43c2-b09c-08d890fa2c1f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 멀티데이 이벤트 시간 표시 개선: "M/D 시작시간 - M/D 종료시간" 형식으로 표시됨 (예: "2/15 18:45 - 2/16 19:30")
  * 일정 생성, 수정, 삭제 기능 완성
  * 월간 캘린더 뷰에서 멀티데이 이벤트와 단일 일정의 최적화된 레이아웃 렌더링

* **Improvements**
  * 전일 일정 처리 로직 강화
  * 이벤트 색상 표시 지원 추가
  * 캘린더 셀 표시 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->