### PR TITLE
[Refactor] 관심 분야 설정뷰 자동 줄바꿈 레이아웃으로 변경

### DIFF
--- a/Planvas/Planvas/Features/Onboarding/View/InterestActivitySelectionView.swift
+++ b/Planvas/Planvas/Features/Onboarding/View/InterestActivitySelectionView.swift
@@ -55,7 +55,7 @@ struct InterestActivitySelectionView: View {
             
             // 관심 분야 선택
             InterestActivitySelectionGroup
-                .padding(.horizontal, 20)
+                .padding(.leading, 20)
             
             Spacer()
             
@@ -166,36 +166,25 @@ struct InterestActivitySelectionView: View {
             Text("관심 분야 선택")
                 .textStyle(.semibold20)
                 .foregroundStyle(.black1)
-            
+
             Spacer().frame(height: 2)
-            
+
             Text("최대 3개")
                 .textStyle(.medium16)
                 .foregroundStyle(.primary1)
                 .padding(.bottom, 15)
-            
-            let items = viewModel.interestActivityTypes
-            
-            VStack(alignment: .leading, spacing: 10) {
-                rowView(Array(items.prefix(3)))
-                rowView(Array(items.dropFirst(3).prefix(3)))
-                rowView(Array(items.dropFirst(6)))
+
+            FlowLayout(spacing: 5) {
+                ForEach(viewModel.interestActivityTypes) { item in
+                    InterestActivityComponent(
+                        emoji: item.emoji,
+                        title: item.title,
+                        isSelected: viewModel.isInterestSelected(item.id),
+                        onTap: { viewModel.toggleInterest(item.id) }
+                    )
+                }
             }
-        }
-    }
-    
-    // MARK: - 관심 분야 배열 한 줄씩
-    private func rowView(_ rowItems: [InterestActivityType]) -> some View {
-        HStack(spacing: 7) {
-            ForEach(rowItems) { item in
-                InterestActivityComponent(
-                    emoji: item.emoji,
-                    title: item.title,
-                    isSelected: viewModel.isInterestSelected(item.id),
-                    onTap: { viewModel.toggleInterest(item.id) }
-                )
-            }
-            Spacer()
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #6 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
* 폰 규격에 따라 화면의 양옆이 잘리는 이슈를 발견하여 자동으로 카테고리칩들이 자동으로 줄바꿈되도록 레이아웃 변경하였습니다.

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 온보딩 화면에서 관심사 선택 항목의 레이아웃 시스템이 개선되어 더 효율적인 배열을 제공합니다.
  * 항목 정렬과 간격이 최적화되어 사용자 인터페이스의 시각적 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->