### PR TITLE
[Fix] 활동 탐색 페이지 진입 시 관심 분야 자동 로드되도록 수정

### DIFF
--- a/Planvas/Planvas/Features/Activity/Navigation/ActivityFlowView.swift
+++ b/Planvas/Planvas/Features/Activity/Navigation/ActivityFlowView.swift
@@ -13,6 +13,7 @@ struct ActivityFlowView: View {
     @State private var goalVM = GoalSetupViewModel()
     
     @State private var didFetchInterests = false
+    @State private var isFetchingInterests = false
     private let provider = APIManager.shared.createProvider(for: OnboardingAPI.self)
     
     var body: some View {
@@ -39,18 +40,25 @@ struct ActivityFlowView: View {
     // MARK: - 활동 목록 페이지 들어갔을 때 선택해뒀던 관심 분야 바로 나오도록
     private func fetchMyInterestsIfNeeded() {
         if didFetchInterests { return }
-        if !goalVM.selectedInterestIds.isEmpty { return }
-        
-        didFetchInterests = true
+        if isFetchingInterests { return }
+        if !goalVM.selectedInterestIds.isEmpty {
+            didFetchInterests = true
+            return
+        }
+
+        isFetchingInterests = true
 
         provider.request(.getMyInterests) { result in
             DispatchQueue.main.async {
+                defer { self.isFetchingInterests = false }
+
                 switch result {
                 case .success(let response):
                     guard (200..<300).contains(response.statusCode) else {
                         print("관심사 조회 실패 status: \(response.statusCode)")
                         return
                     }
+
                     do {
                         let decoded = try JSONDecoder().decode(MyInterestsResponseDTO.self, from: response.data)
                         let interests = decoded.success?.interests ?? []
@@ -62,6 +70,8 @@ struct ActivityFlowView: View {
                         )
 
                         goalVM.selectedInterestIds = mappedUUIDs
+                        self.didFetchInterests = true
+
                     } catch {
                         print("관심사 디코딩 오류: \(error)")
                     }


### PR DESCRIPTION

<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #69

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
활동 탐색 페이지 진입 시 관심 분야 자동 로드되도록 수정

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 활동 흐름 뷰 진입 시 이전에 선택한 관심사가 자동으로 미리 채워집니다.
  * 진입 시 필요하면 서버에서 관심사를 배경으로 가져와 UI에 반영해 빠르게 표시됩니다.

* **버그 수정 / 개선**
  * 중복 요청을 방지하고 로딩 상태를 안정적으로 관리해 화면 반응성이 향상되었습니다.
  * 서버 응답 처리와 오류 상황이 개선되어 불완전한 데이터로 인한 표시 오류 가능성이 줄었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->