### PR TITLE
[Feat] 반복 일정 API 연결 수정

### DIFF
--- a/Planvas/Planvas/Features/Calendar/Repository/CalendarAPIRepository.swift
+++ b/Planvas/Planvas/Features/Calendar/Repository/CalendarAPIRepository.swift
@@ -59,9 +59,12 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
         let categoryStr = event.category == .none ? "GROWTH" : event.category.rawValue
         let colorInt = event.color.serverColor
         let rule = Self.buildRecurrenceRule(from: event)
+        let recurrenceEndAt: String? = (event.isRepeating && event.repeatEndDate != nil)
+            ? dateKeyString(from: event.repeatEndDate!)
+            : nil
         _ = try await networkService.createEvent(
             title: event.title, startAt: startAt, endAt: endAt, type: "FIXED",
-            category: categoryStr, eventColor: colorInt, recurrenceRule: rule
+            category: categoryStr, eventColor: colorInt, recurrenceRule: rule, recurrenceEndAt: recurrenceEndAt
         )
     }
 

--- a/Planvas/Planvas/Service/Calendar/CalendarDTO.swift
+++ b/Planvas/Planvas/Service/Calendar/CalendarDTO.swift
@@ -178,10 +178,11 @@ struct CreateEventRequestDTO: Encodable {
     let title: String
     let startAt: String   // ISO 8601 (e.g. "2026-02-12T18:10:00+09:00")
     let endAt: String
-    let type: String      // "FIXED"
+    let type: String      // "FIXED" (직접 추가·고정 일정) | "ACTIVITY" (활동 일정)
     let category: String  // "GROWTH" | "REST"
     let eventColor: Int   // 1~10
     let recurrenceRule: String?
+    let recurrenceEndAt: String?  // "yyyy-MM-dd", 반복 일정인 경우 필수
 }
 
 struct CreateEventResponse: Decodable {

--- a/Planvas/Planvas/Service/Calendar/CalendarNetworkService.swift
+++ b/Planvas/Planvas/Service/Calendar/CalendarNetworkService.swift
@@ -86,9 +86,9 @@ final class CalendarNetworkService: @unchecked Sendable {
 
     /// 일정 추가 POST /api/calendar/event
     func createEvent(title: String, startAt: String, endAt: String, type: String = "FIXED",
-                     category: String, eventColor: Int, recurrenceRule: String?) async throws -> CreateEventSuccess {
+                     category: String, eventColor: Int, recurrenceRule: String?, recurrenceEndAt: String?) async throws -> CreateEventSuccess {
         let body = CreateEventRequestDTO(title: title, startAt: startAt, endAt: endAt, type: type,
-                                         category: category, eventColor: eventColor, recurrenceRule: recurrenceRule)
+                                         category: category, eventColor: eventColor, recurrenceRule: recurrenceRule, recurrenceEndAt: recurrenceEndAt)
         let response: CreateEventResponse = try await request(.postEvent(body: body))
         if let error = response.error {
             throw CalendarAPIError.serverFail(reason: error.reason)


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #114

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
- 이제 반복 일정 추가 가능합니다. 
- 활동으로 추가한 일정은 캘린더에서 종료일에만 보입니다. 

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 반복 이벤트의 종료 날짜 설정 기능을 추가했습니다. 이제 반복되는 이벤트에 대해 선택적으로 종료 날짜를 지정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->