### PR TITLE
[Refactor] 프리뷰에서 안 뜨는 일정들 일간 조회로 보충

### DIFF
--- a/Planvas/Planvas/Features/Calendar/Repository/CalendarAPIRepository.swift
+++ b/Planvas/Planvas/Features/Calendar/Repository/CalendarAPIRepository.swift
@@ -72,9 +72,8 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
     /// 일정 추가 (직접 추가)
     /// - API: `POST /api/calendar/event`
     /// - Body: title, startAt, endAt, type: "FIXED", category, eventColor, recurrenceRule, recurrenceEndAt(반복일 때)
-    /// - 사용처: AddEventView "저장" → viewModel.addEvent(event)
-    /// - 후처리: 성공 시 ViewModel에서 refreshEvents()로 월간·일간 재조회
-    func addEvent(_ event: Event) async throws {
+    /// - 반환: 생성된 일정 id (그리드 반영용 상세 조회에 사용)
+    func addEvent(_ event: Event) async throws -> Int {
         let (startAt, endAt) = formatEventTimes(event)
         let categoryStr = event.category == .none ? "GROWTH" : event.category.rawValue
         let colorInt = event.color.serverColor
@@ -82,10 +81,11 @@ final class CalendarAPIRepository: CalendarRepositoryProtocol {
         let recurrenceEndAt: String? = (event.isRepeating && event.repeatEndDate != nil)
             ? dateKeyString(from: event.repeatEndDate!)
             : nil
-        _ = try await networkService.createEvent(
+        let success = try await networkService.createEvent(
             title: event.title, startAt: startAt, endAt: endAt, type: "FIXED",
             category: categoryStr, eventColor: colorInt, recurrenceRule: rule, recurrenceEndAt: recurrenceEndAt
         )
+        return success.id
     }
 
     /// 일정 수정

--- a/Planvas/Planvas/Features/Calendar/Repository/CalendarRepository.swift
+++ b/Planvas/Planvas/Features/Calendar/Repository/CalendarRepository.swift
@@ -25,8 +25,8 @@ protocol CalendarRepositoryProtocol {
     /// 특정 날짜 범위의 이벤트 목록을 가져옵니다 (여러 일간 조회용)
     func getEvents(from startDate: Date, to endDate: Date) async throws -> [Event]
     
-    /// 이벤트를 추가합니다
-    func addEvent(_ event: Event) async throws
+    /// 이벤트를 추가합니다. 성공 시 생성된 일정 id(서버 itemId) 반환.
+    func addEvent(_ event: Event) async throws -> Int
     
     /// 이벤트를 업데이트합니다
     func updateEvent(_ event: Event) async throws
@@ -152,8 +152,8 @@ final class CalendarRepository: CalendarRepositoryProtocol {
         return allEvents
     }
     
-    func addEvent(_ event: Event) async throws {
-        // Mock: 무시 (API 연동 완료, CalendarAPIRepository 사용)
+    func addEvent(_ event: Event) async throws -> Int {
+        0
     }
 
     func updateEvent(_ event: Event) async throws {


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #125

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
- 월간 일정 조회에서 조회 안 되는 것들 일간 일정 조회로 보충했습니다. 

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캘린더에서 새로 생성된 이벤트가 이벤트 그리드에 올바르게 표시되도록 개선했습니다.
  * 날짜 선택 시 해당 날짜의 이벤트를 비동기로 로드하도록 변경했습니다.
  * 반복 이벤트 및 여러 날짜에 걸친 이벤트 처리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->