### PR TITLE
[Fix] 활동 디테일 뷰 렌더링 안뜨는 이슈 수정

### DIFF
--- a/Planvas/Planvas/Features/Activity/Models/ActivityModel.swift
+++ b/Planvas/Planvas/Features/Activity/Models/ActivityModel.swift
@@ -58,10 +58,27 @@ struct ActivityDetail {
 
 extension ActivityDetailSuccess {
     func toDomain() -> ActivityDetail {
-        
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
-        
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+
+        let start = startDate.flatMap { formatter.date(from: $0) }
+        let end = endDate.flatMap { formatter.date(from: $0) }
+
+        let dateText: String = {
+            switch (startDate, endDate) {
+            case let (s?, e?):
+                return "\(s) ~ \(e)"
+            case let (nil, e?):
+                return "~ \(e)"
+            case let (s?, nil):
+                return "\(s) ~"
+            default:
+                return "날짜 정보 없음"
+            }
+        }()
+
         return ActivityDetail(
             activityId: activityId,
             title: title,
@@ -70,9 +87,9 @@ extension ActivityDetailSuccess {
             description: description,
             thumbnailUrl: thumbnailUrl ?? "",
             dDay: dDay,
-            date: "\(startDate) ~ \(endDate)",
-            startDate: formatter.date(from: startDate),
-            endDate: formatter.date(from: endDate),
+            date: dateText,
+            startDate: start,
+            endDate: end,
             minPoint: minPoint,
             maxPoint: maxPoint,
             defaultPoint: defaultPoint,

--- a/Planvas/Planvas/Service/Activity/ActivityDTO.swift
+++ b/Planvas/Planvas/Service/Activity/ActivityDTO.swift
@@ -39,8 +39,8 @@ struct ActivityDetailSuccess: Decodable {
     let description: String
     let thumbnailUrl: String?
     let type:  String?
-    let startDate: String
-    let endDate: String
+    let startDate: String?
+    let endDate: String?
     let dDay: Int
     let scheduleStatus: ScheduleStatusCategory
     let tipMessage: String?


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #134 

### ✨️ 작업 내용
* 활동 상세 날짜 null 값으로 들어오는 이슈가 있어서 옵셔널 처리했습니다.

작업 내용을 간략히 설명해주세요.

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
<img width="309" height="74" alt="스크린샷 2026-02-17 22 53 31" src="https://github.com/user-attachments/assets/fbcf822d-3893-4092-829b-42e80f7a2944" />

시작 날짜 안들어옴;;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 활동 날짜 표시 방식 개선 - 시작일, 종료일의 유무에 따라 맞춤형 형식으로 표시됩니다.
  * 날짜 정보가 없을 때 사용자 친화적인 메시지 표시
  * 서울 시간대 기준의 정확한 날짜 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->