### PR TITLE
[Fix] 목록의 일정 시간 정보 제대로 가져오도록 수정

### DIFF
--- a/Planvas/Planvas/Features/Calendar/ViewModel/CalendarViewModel.swift
+++ b/Planvas/Planvas/Features/Calendar/ViewModel/CalendarViewModel.swift
@@ -631,6 +631,8 @@ final class CalendarViewModel {
             sampleEvents = newSample
             let selectedKey = dateKeyString(from: selectedDate)
             selectedDateEvents = sampleEvents[selectedKey] ?? []
+            // 선택된 날(보통 오늘)은 일간 API로 한 번 더 조회해 시간 정보가 제대로 나오도록 수정
+            await loadEventsForDate(selectedDate)
         } catch {
             print("월간 캘린더 조회 실패: \(error)")
         }


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #136

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.
- 캘린더 탭 눌렀을 때 선택된 날짜(보통 당일) 일정의 시간 정보가 하루종일로 뜨는 문제 수정

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
