### PR TITLE
[Fix] 장바구니 페이지 일정 추가 알림창 문구 수정

### DIFF
--- a/Planvas/Planvas/Features/Activity/ViewModel/CartViewModel.swift
+++ b/Planvas/Planvas/Features/Activity/ViewModel/CartViewModel.swift
@@ -142,8 +142,8 @@ class CartViewModel {
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { [weak self] completion in
                 if case let .failure(error) = completion {
-                    self?.errorMessage = "일정 추가 실패 \(error.localizedDescription)"
-                    self?.alertErrorMessage = "기존에 존재하는 일정과 겹칩니다."
+                    self?.errorMessage = "일정 추가 실패: \(error.localizedDescription)"
+                    self?.alertErrorMessage = self?.serverReason(from: error)
                 }
             }, receiveValue: { [weak self] response in
                 if response.resultType == "SUCCESS" {
@@ -153,5 +153,17 @@ class CartViewModel {
                 }
             })
             .store(in: &cancellable)
+    }
+}
+
+extension CartViewModel {
+    private func serverReason(from error: MoyaError) -> String {
+        if let response = error.response,
+           let json = try? JSONSerialization.jsonObject(with: response.data) as? [String: Any],
+           let errorDict = json["error"] as? [String: Any],
+           let reason = errorDict["reason"] as? String {
+            return reason
+        }
+        return "일정 추가에 실패했습니다. 다시 시도해 주세요."
     }
 }


### PR DESCRIPTION
### 📑 이슈 번호

- close #156 

### ✨️ 작업 내용

일정 추가 실패시 서버에서 온 에러메시지 출력

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

https://github.com/user-attachments/assets/d4bf8ead-95c2-49fa-97af-100fcc2b32aa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 활동 항목 추가 시 오류 메시지를 개선했습니다. 서버에서 제공하는 상세한 오류 메시지를 표시하여 사용자가 문제를 더 잘 이해할 수 있도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->