### PR TITLE
[Fix] 주간 캘린더 스케줄 슬롯 관리

### DIFF
--- a/Planvas/Planvas/Features/Main/Components/Calendar/CalendarGroup.swift
+++ b/Planvas/Planvas/Features/Main/Components/Calendar/CalendarGroup.swift
@@ -11,6 +11,10 @@ import SwiftUI
 struct CalendarGroup: View {
     @Bindable var viewModel: MainViewModel
     
+    private var slotAssignment: [Int: Int] {
+        ScheduleSlotAssigner.assignSlots(for: viewModel.weeklyBarSchedules)
+    }
+    
     var body: some View {
         VStack(alignment: .leading){
             Text("이번 주")
@@ -41,7 +45,8 @@ struct CalendarGroup: View {
                             weeklyBarSchedules: viewModel.weeklyBarSchedules,
                             recurringSchedules: viewModel.allSchedules.filter {
                                 $0.recurrenceRule != nil && !$0.recurrenceRule!.isEmpty
-                            }
+                            },
+                            slotAssignment: slotAssignment
                         )
                     }
                 }

--- a/Planvas/Planvas/Features/Main/Components/Calendar/DateItem.swift
+++ b/Planvas/Planvas/Features/Main/Components/Calendar/DateItem.swift
@@ -14,6 +14,21 @@ struct DateItem: View {
     @Binding var selectedDate: Date
     let weeklyBarSchedules: [Schedule]
     let recurringSchedules: [Schedule]
+    let slotAssignment: [Int: Int]
+    
+    // 이 날짜에 표시할 슬롯별 일정 (slot 0,1,2 순서, nil = 빈 슬롯)
+    private var slottedSchedules: [Int: Schedule] {
+        var result: [Int: Schedule] = [:]
+        let today = Calendar.current.startOfDay(for: date)
+
+        for schedule in weeklyBarSchedules {
+            guard schedule.dates.contains(today),
+                  let slot = slotAssignment[schedule.id],
+                  slot < 3 else { continue }
+            result[slot] = schedule
+        }
+        return result
+    }
     
     var body: some View {
         VStack(spacing: 6) {
@@ -40,9 +55,9 @@ struct DateItem: View {
                 
                 // 일정 목록
                 VStack(spacing: 0) {
-                    ForEach(weeklyBarSchedules) { schedule in
+                    ForEach(0..<3, id: \.self) { slot in
                         Group {
-                            if schedule.dates.contains(Calendar.current.startOfDay(for: date)) {
+                            if let schedule = slottedSchedules[slot] {
                                 ScheduleItem(schedule: schedule, date: date)
                             } else {
                                 Color.clear


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #148

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

> 주간 캘린더 스케줄 슬롯 관리

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 캘린더 일정 표시 개선: 일정 겹침 문제를 해결하여 날짜별 최대 3개의 일정이 깔끔하게 정렬되어 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->